### PR TITLE
Possibility to specify assemblyCompareMode

### DIFF
--- a/src/main/java/org/sonar/plugins/fxcop/FxCopConfiguration.java
+++ b/src/main/java/org/sonar/plugins/fxcop/FxCopConfiguration.java
@@ -37,9 +37,10 @@ public class FxCopConfiguration {
   private final String aspnetPropertyKey;
   private final String directoriesPropertyKey;
   private final String referencesPropertyKey;
+  private final String assemblyCompareModePropertyKey;
 
   public FxCopConfiguration(String languageKey, String repositoryKey, String assemblyPropertyKey, String fxCopCmdPropertyKey, String timeoutPropertyKey, String aspnetPropertyKey,
-    String directoriesPropertyKey, String referencesPropertyKey) {
+    String directoriesPropertyKey, String referencesPropertyKey, String assemblyCompareModePropertyKey) {
     this.languageKey = languageKey;
     this.repositoryKey = repositoryKey;
     this.assemblyPropertyKey = assemblyPropertyKey;
@@ -48,6 +49,7 @@ public class FxCopConfiguration {
     this.aspnetPropertyKey = aspnetPropertyKey;
     this.directoriesPropertyKey = directoriesPropertyKey;
     this.referencesPropertyKey = referencesPropertyKey;
+    this.assemblyCompareModePropertyKey = assemblyCompareModePropertyKey;
   }
 
   public String languageKey() {
@@ -80,6 +82,10 @@ public class FxCopConfiguration {
 
   public String referencesPropertyKey() {
     return referencesPropertyKey;
+  }
+
+  public String assemblyCompareModePropertyKey() {
+    return assemblyCompareModePropertyKey;
   }
 
   public void checkProperties(Settings settings) {

--- a/src/main/java/org/sonar/plugins/fxcop/FxCopExecutor.java
+++ b/src/main/java/org/sonar/plugins/fxcop/FxCopExecutor.java
@@ -34,7 +34,7 @@ public class FxCopExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(FxCopExecutor.class);
   private static final String EXECUTABLE = "FxCopCmd.exe";
 
-  public void execute(String executable, String assemblies, File rulesetFile, File reportFile, int timeout, boolean aspnet, List<String> directories, List<String> references) {
+  public void execute(String executable, String assemblies, File rulesetFile, File reportFile, int timeout, boolean aspnet, List<String> directories, List<String> references, String assemblyCompareMode) {
     Command command = Command.create(getExecutable(executable))
       .addArgument("/file:" + assemblies)
       .addArgument("/ruleset:=" + rulesetFile.getAbsolutePath())
@@ -45,6 +45,9 @@ public class FxCopExecutor {
 
     if (aspnet) {
       command.addArgument("/aspnet");
+    }
+    if (assemblyCompareMode != null) {
+      command.addArgument("/assemblyCompareMode:" + assemblyCompareMode);
     }
 
     for (String directory : directories) {

--- a/src/main/java/org/sonar/plugins/fxcop/FxCopSensor.java
+++ b/src/main/java/org/sonar/plugins/fxcop/FxCopSensor.java
@@ -97,7 +97,8 @@ public class FxCopSensor implements Sensor {
 
     executor.execute(settings.getString(fxCopConf.fxCopCmdPropertyKey()), settings.getString(fxCopConf.assemblyPropertyKey()),
       rulesetFile, reportFile, settings.getInt(fxCopConf.timeoutPropertyKey()), settings.getBoolean(fxCopConf.aspnetPropertyKey()),
-      splitOnCommas(settings.getString(fxCopConf.directoriesPropertyKey())), splitOnCommas(settings.getString(fxCopConf.referencesPropertyKey())));
+      splitOnCommas(settings.getString(fxCopConf.directoriesPropertyKey())), splitOnCommas(settings.getString(fxCopConf.referencesPropertyKey())),
+      settings.getString(fxCopConf.assemblyCompareModePropertyKey()));
 
     for (FxCopIssue issue : parser.parse(reportFile)) {
       if (!hasFileAndLine(issue)) {

--- a/src/test/java/org/sonar/plugins/fxcop/FxCopConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/fxcop/FxCopConfigurationTest.java
@@ -38,7 +38,7 @@ public class FxCopConfigurationTest {
   @Test
   public void test() {
     FxCopConfiguration fxCopConf = new FxCopConfiguration("cs", "cs-fxcop", "fooAssemblyKey", "fooFxCopCmdPathKey", "fooTimeoutKey", "fooAspnetKey", "fooDirectoriesKey",
-      "fooReferencesKey");
+      "fooReferencesKey", "fooAssemblyCompareMode");
     assertThat(fxCopConf.languageKey()).isEqualTo("cs");
     assertThat(fxCopConf.repositoryKey()).isEqualTo("cs-fxcop");
     assertThat(fxCopConf.assemblyPropertyKey()).isEqualTo("fooAssemblyKey");
@@ -47,8 +47,9 @@ public class FxCopConfigurationTest {
     assertThat(fxCopConf.aspnetPropertyKey()).isEqualTo("fooAspnetKey");
     assertThat(fxCopConf.directoriesPropertyKey()).isEqualTo("fooDirectoriesKey");
     assertThat(fxCopConf.referencesPropertyKey()).isEqualTo("fooReferencesKey");
+    assertThat(fxCopConf.assemblyCompareModePropertyKey()).isEqualTo("fooAssemblyCompareMode");
 
-    fxCopConf = new FxCopConfiguration("vbnet", "vbnet-fxcop", "barAssemblyKey", "barFxCopCmdPathKey", "barTimeoutKey", "barAspnetKey", "barDirectoriesKey", "barReferencesKey");
+    fxCopConf = new FxCopConfiguration("vbnet", "vbnet-fxcop", "barAssemblyKey", "barFxCopCmdPathKey", "barTimeoutKey", "barAspnetKey", "barDirectoriesKey", "barReferencesKey", "barAssemblyCompareMode");
     assertThat(fxCopConf.languageKey()).isEqualTo("vbnet");
     assertThat(fxCopConf.repositoryKey()).isEqualTo("vbnet-fxcop");
     assertThat(fxCopConf.assemblyPropertyKey()).isEqualTo("barAssemblyKey");
@@ -57,6 +58,7 @@ public class FxCopConfigurationTest {
     assertThat(fxCopConf.aspnetPropertyKey()).isEqualTo("barAspnetKey");
     assertThat(fxCopConf.directoriesPropertyKey()).isEqualTo("barDirectoriesKey");
     assertThat(fxCopConf.referencesPropertyKey()).isEqualTo("barReferencesKey");
+    assertThat(fxCopConf.assemblyCompareModePropertyKey()).isEqualTo("barAssemblyCompareMode");
   }
 
   @Test
@@ -67,7 +69,7 @@ public class FxCopConfigurationTest {
     when(settings.hasKey("fooFxCopCmdPathKey")).thenReturn(true);
     when(settings.getString("fooFxCopCmdPathKey")).thenReturn(new File("src/test/resources/FxCopConfigurationTest/FxCopCmd.exe").getAbsolutePath());
 
-    new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "", "").checkProperties(settings);
+    new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "", "", "").checkProperties(settings);
   }
 
   @Test
@@ -78,7 +80,7 @@ public class FxCopConfigurationTest {
     when(settings.hasKey("fooFxCopCmdPathKey")).thenReturn(true);
     when(settings.getString("fooFxCopCmdPathKey")).thenReturn(new File("src/test/resources/FxCopConfigurationTest/FxCopCmd.exe").getAbsolutePath());
 
-    new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "", "").checkProperties(settings);
+    new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "", "", "").checkProperties(settings);
   }
 
   @Test
@@ -91,7 +93,7 @@ public class FxCopConfigurationTest {
     Settings settings = mock(Settings.class);
     when(settings.hasKey("fooAssemblyKey")).thenReturn(false);
 
-    new FxCopConfiguration("", "", "fooAssemblyKey", "", "", "", "", "").checkProperties(settings);
+    new FxCopConfiguration("", "", "fooAssemblyKey", "", "", "", "", "", "").checkProperties(settings);
   }
 
   @Test
@@ -105,7 +107,7 @@ public class FxCopConfigurationTest {
     when(settings.hasKey("fooAssemblyKey")).thenReturn(true);
     when(settings.getString("fooAssemblyKey")).thenReturn(new File("src/test/resources/FxCopConfigurationTest/MyLibraryNotFound.dll").getAbsolutePath());
 
-    new FxCopConfiguration("", "", "fooAssemblyKey", "", "", "", "", "").checkProperties(settings);
+    new FxCopConfiguration("", "", "fooAssemblyKey", "", "", "", "", "", "").checkProperties(settings);
   }
 
   @Test
@@ -119,7 +121,7 @@ public class FxCopConfigurationTest {
     when(settings.hasKey("fooAssemblyKey")).thenReturn(true);
     when(settings.getString("fooAssemblyKey")).thenReturn(new File("src/test/resources/FxCopConfigurationTest/MyLibraryWithoutPdb.dll").getAbsolutePath());
 
-    new FxCopConfiguration("", "", "fooAssemblyKey", "", "", "", "", "").checkProperties(settings);
+    new FxCopConfiguration("", "", "fooAssemblyKey", "", "", "", "", "", "").checkProperties(settings);
   }
 
   @Test
@@ -128,7 +130,7 @@ public class FxCopConfigurationTest {
     settings.setProperty("fooAssemblyKey", "src/test/resources/FxCopConfigurationTest/MyLibrary.dll");
     settings.setProperty("sonar.fxcop.installDirectory", new File("src/test/resources/FxCopConfigurationTest/FxCopCmd.exe").getAbsolutePath());
 
-    FxCopConfiguration fxCopConf = new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "", "");
+    FxCopConfiguration fxCopConf = new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "", "", "");
     fxCopConf.checkProperties(settings);
 
     assertThat(settings.getString(fxCopConf.fxCopCmdPropertyKey())).isEqualTo(new File("src/test/resources/FxCopConfigurationTest/FxCopCmd.exe").getAbsolutePath());
@@ -145,7 +147,7 @@ public class FxCopConfigurationTest {
     settings.setProperty("fooAssemblyKey", "src/test/resources/FxCopConfigurationTest/MyLibrary.dll");
     settings.setProperty("fooFxCopCmdPathKey", new File("src/test/resources/FxCopConfigurationTest/FxCopCmdNotFound.exe").getAbsolutePath());
 
-    new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "", "").checkProperties(settings);
+    new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "", "", "").checkProperties(settings);
   }
 
   @Test
@@ -155,7 +157,7 @@ public class FxCopConfigurationTest {
     settings.setProperty("fooFxCopCmdPathKey", new File("src/test/resources/FxCopConfigurationTest/FxCopCmd.exe").getAbsolutePath());
     settings.setProperty("sonar.fxcop.timeoutMinutes", "42");
 
-    FxCopConfiguration fxCopConf = new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "fooTimeoutKey", "", "", "");
+    FxCopConfiguration fxCopConf = new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "fooTimeoutKey", "", "", "", "");
     fxCopConf.checkProperties(settings);
 
     assertThat(settings.getString(fxCopConf.timeoutPropertyKey())).isEqualTo("42");

--- a/src/test/java/org/sonar/plugins/fxcop/FxCopRuleRepositoryTest.java
+++ b/src/test/java/org/sonar/plugins/fxcop/FxCopRuleRepositoryTest.java
@@ -32,7 +32,7 @@ public class FxCopRuleRepositoryTest {
 
   @Test
   public void test_cs() {
-    FxCopRuleRepository repo = new FxCopRuleRepository(new FxCopConfiguration("cs", "cs-fxcop", "", "", "", "", "", ""), new XMLRuleParser());
+    FxCopRuleRepository repo = new FxCopRuleRepository(new FxCopConfiguration("cs", "cs-fxcop", "", "", "", "", "", "", ""), new XMLRuleParser());
     assertThat(repo.getLanguage()).isEqualTo("cs");
     assertThat(repo.getKey()).isEqualTo("cs-fxcop");
 
@@ -49,7 +49,7 @@ public class FxCopRuleRepositoryTest {
 
   @Test
   public void test_vbnet() {
-    FxCopRuleRepository repo = new FxCopRuleRepository(new FxCopConfiguration("vbnet", "vbnet-fxcop", "", "", "", "", "", ""), new XMLRuleParser());
+    FxCopRuleRepository repo = new FxCopRuleRepository(new FxCopConfiguration("vbnet", "vbnet-fxcop", "", "", "", "", "", "", ""), new XMLRuleParser());
     assertThat(repo.getLanguage()).isEqualTo("vbnet");
     assertThat(repo.getKey()).isEqualTo("vbnet-fxcop");
 

--- a/src/test/java/org/sonar/plugins/fxcop/FxCopSensorTest.java
+++ b/src/test/java/org/sonar/plugins/fxcop/FxCopSensorTest.java
@@ -61,7 +61,7 @@ public class FxCopSensorTest {
     Project project = mock(Project.class);
 
     FxCopSensor sensor = new FxCopSensor(
-      new FxCopConfiguration("", "foo-fxcop", "", "", "", "", "", ""),
+      new FxCopConfiguration("", "foo-fxcop", "", "", "", "", "", "", ""),
       settings, profile, fileSystem, perspectives);
 
     when(fileSystem.files(Mockito.any(FileQuery.class))).thenReturn(ImmutableList.<File>of());
@@ -92,6 +92,7 @@ public class FxCopSensorTest {
     when(fxCopConf.aspnetPropertyKey()).thenReturn("aspnet");
     when(fxCopConf.directoriesPropertyKey()).thenReturn("directories");
     when(fxCopConf.referencesPropertyKey()).thenReturn("references");
+    when(fxCopConf.assemblyCompareModePropertyKey()).thenReturn("assembly-compare-mode");
 
     FxCopSensor sensor = new FxCopSensor(
       fxCopConf,
@@ -115,6 +116,7 @@ public class FxCopSensorTest {
     when(settings.getBoolean("aspnet")).thenReturn(true);
     when(settings.getString("directories")).thenReturn(" c:/,,  d:/ ");
     when(settings.getString("references")).thenReturn(null);
+    when(settings.getString("assembly-compare-mode")).thenReturn("compareUsingMyMode");
 
     org.sonar.api.resources.File fooSonarFileWithIssuable = mockSonarFile("foo");
     org.sonar.api.resources.File fooSonarFileWithoutIssuable = mockSonarFile("foo");
@@ -162,7 +164,7 @@ public class FxCopSensorTest {
 
     verify(writer).write(ImmutableList.of("CA0000", "CA1000", "CR1000"), new File(workingDir, "fxcop-sonarqube.ruleset"));
     verify(executor).execute("FxCopCmd.exe", "MyLibrary.dll", new File(workingDir, "fxcop-sonarqube.ruleset"), new File(workingDir, "fxcop-report.xml"), 42, true,
-      ImmutableList.of("c:/", "d:/"), ImmutableList.<String>of());
+      ImmutableList.of("c:/", "d:/"), ImmutableList.<String>of(), "compareUsingMyMode");
 
     verify(issuable).addIssue(issue1);
     verify(issuable).addIssue(issue2);
@@ -185,7 +187,7 @@ public class FxCopSensorTest {
   public void check_properties() {
     thrown.expectMessage("fooAssemblyKey");
 
-    FxCopConfiguration fxCopConf = new FxCopConfiguration("", "", "fooAssemblyKey", "", "", "", "", "");
+    FxCopConfiguration fxCopConf = new FxCopConfiguration("", "", "fooAssemblyKey", "", "", "", "", "", "");
     new FxCopSensor(fxCopConf, mock(Settings.class), mock(RulesProfile.class), mock(ModuleFileSystem.class), mock(ResourcePerspectives.class))
       .analyse(mock(Project.class), mock(SensorContext.class));
   }


### PR DESCRIPTION
Added the possibility to specify the assemblCompareMode to the
FXCop executable. This is useful if/when the provided assemblies
do not contain a referenced assembly in the exact same version

Change-Id: I65fbbf161094d08199bc731412c3ec75cf598093